### PR TITLE
Fix compile error

### DIFF
--- a/src/libs/socket_service.h
+++ b/src/libs/socket_service.h
@@ -8,6 +8,7 @@
 #include <atomic>
 #include <sstream>
 #include <functional>
+#include <memory>
 #include <unordered_set>
 #include "ring_buffer.h"
 


### PR DESCRIPTION
 error: 'shared_ptr' in namespace 'std' does not name a template type